### PR TITLE
Designing the API as MPSC channels

### DIFF
--- a/src/backend/switch/tungstenite.rs
+++ b/src/backend/switch/tungstenite.rs
@@ -6,11 +6,13 @@ use tokio_tungstenite::{connect_async, WebSocketStream, MaybeTlsStream};
 pub use tokio_tungstenite::tungstenite::Error;
 use tokio::net::TcpStream;
 use futures_util::SinkExt;
+use std::sync::{Arc, Mutex};
 
 use crate::message::Message;
 use futures_util::StreamExt;
-use tokio_tungstenite::tungstenite::protocol::CloseFrame;
-use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+// use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+// use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use futures_util::stream::{SplitSink, SplitStream};
 
 impl From<tokio_tungstenite::tungstenite::Message> for Message {
     fn from(message: tokio_tungstenite::tungstenite::Message) -> Self {
@@ -30,38 +32,56 @@ impl From<tokio_tungstenite::tungstenite::Message> for Message {
     }
 }
 
-/// Stream based WebSocket.
+/// Stream-based WebSocket.
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub struct WebSocket {
+pub struct WebSocket {}
+
+/// WebSocket sender. Also responsible for closing the connection.
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
+pub struct WebSocketSender {
     #[derivative(Debug="ignore")]
-    socket: WebSocketStream<MaybeTlsStream<TcpStream>>
+    sender: Arc<Mutex<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, tokio_tungstenite::tungstenite::Message>>>
+}
+
+/// Stream-based WebSocket receiver.
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct WebSocketReceiver {
+    #[derivative(Debug="ignore")]
+    receiver: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>
 }
 
 impl WebSocket {
     /// Creates a new WebSocket and connects it to the specified `url`.
     /// Returns `ConnectionError` if it can't connect.
-    pub async fn new(url: &str) -> WebsocketResult<Self> {
+    pub async fn new(url: &str) -> WebsocketResult<(WebSocketSender, WebSocketReceiver)> {
         connect_async(url)
             .await
-            .map(|(socket, _response)| Self { socket })
+            .map(|(socket, _response)| {
+                let (sender, receiver) = socket.split();
+                let sender = Arc::new(Mutex::new(sender));
+                (WebSocketSender { sender }, WebSocketReceiver { receiver })
+            })
             .map_err(|error| crate::error::Error::ConnectionError(error))
     }
+}
 
+impl WebSocketSender {
     /// Attempts to send a message and returns `SendError` if it fails.
     pub async fn send(&mut self, message: &Message) -> WebsocketResult<()> {
         match message {
             Message::Text(text) => {
-                self.socket.send(text.clone().into()).await.map_err(|error| crate::error::Error::SendError(error))
+                let text = text.clone().into();
+                self.sender.lock().expect("Failed to lock sender.").send(text).await.map_err(|error| crate::error::Error::SendError(error))
             },
             Message::Binary(binary) => {
-                self.socket.send(binary.clone().into()).await.map_err(|error| crate::error::Error::SendError(error))
+                let binary = binary.clone().into();
+                self.sender.lock().expect("Failed to lock sender.").send(binary).await.map_err(|error| crate::error::Error::SendError(error))
             },
-            Message::Close(close) => {
-                self.socket.close(close.clone().map(|reason| CloseFrame {
-                    code: CloseCode::Normal,
-                    reason: reason.into()
-                })).await.map_err(|error| crate::error::Error::SendError(error))
+            Message::Close(_close) => {
+                self.sender.lock().expect("Failed to lock sender.").close().await.map_err(|error| crate::error::Error::SendError(error))
             }
         }
     }
@@ -70,10 +90,12 @@ impl WebSocket {
     pub async fn close(&mut self, message: Option<String>) -> WebsocketResult<()> {
         self.send(&Message::Close(message)).await
     }
+}
 
+impl WebSocketReceiver {
     /// Attempts to receive a message and returns `ReceiveError` if it fails.
     pub async fn next(&mut self) -> Option<WebsocketResult<Message>> {
-        self.socket.next().await.map(|result| {
+        self.receiver.next().await.map(|result| {
             result
                 .map(|result| {
                     result.into()

--- a/tests/websocket.rs
+++ b/tests/websocket.rs
@@ -12,34 +12,34 @@ mod tests {
 
     #[cross_test]
     async fn send_after_close() {
-        let mut websocket = WebSocket::new("wss://echo.websocket.org").await.expect("Couldn't connect");
+        let (mut sender, _) = WebSocket::new("wss://echo.websocket.org").await.expect("Couldn't connect");
 
-        websocket.close(None).await.expect("Failed to close WebSocket.");
+        sender.close(None).await.expect("Failed to close WebSocket.");
 
         let expected_message_1 = Message::Text("Hello".into());
-        websocket.send(&expected_message_1).await.expect_err("Sending after closing is not allowed.");
+        sender.send(&expected_message_1).await.expect_err("Sending after closing is not allowed.");
     }
 
     #[cross_test]
     async fn echo() {
-        let mut websocket = WebSocket::new("wss://echo.websocket.org").await.expect("Couldn't connect");
+        let (mut sender, mut receiver) = WebSocket::new("wss://echo.websocket.org").await.expect("Couldn't connect");
 
         let expected_message_1 = Message::Text("Hello".into());
-        websocket.send(&expected_message_1).await.expect("Couldn't send text message 1.");
+        sender.send(&expected_message_1).await.expect("Couldn't send text message 1.");
 
         let expected_message_2 = Message::Binary(vec![1, 2, 3]);
-        websocket.send(&expected_message_2).await.expect("Couldn't send text message 2.");
+        sender.send(&expected_message_2).await.expect("Couldn't send text message 2.");
 
         let expected_message_3 = Message::Text("Echo".into());
-        websocket.send(&expected_message_3).await.expect("Couldn't send binary message 3.");
+        sender.send(&expected_message_3).await.expect("Couldn't send binary message 3.");
 
-        let message = websocket.next().await.expect("Stream has terminated at message 1.").expect("Failed to receive message 1.");
+        let message = receiver.next().await.expect("Stream has terminated at message 1.").expect("Failed to receive message 1.");
         assert_eq!(message, expected_message_1, "Unexpected message 1.");
 
-        let message = websocket.next().await.expect("Stream has terminated at message 2.").expect("Failed to receive message 2.");
+        let message = receiver.next().await.expect("Stream has terminated at message 2.").expect("Failed to receive message 2.");
         assert_eq!(message, expected_message_2, "Unexpected message 2.");
 
-        let message = websocket.next().await.expect("Stream has terminated at message 3.").expect("Failed to receive message 3.");
+        let message = receiver.next().await.expect("Stream has terminated at message 3.").expect("Failed to receive message 3.");
         assert_eq!(message, expected_message_3, "Unexpected message 3.");
     }
 }


### PR DESCRIPTION
Redesigning the API as MPSC channels. This closes #7.