### PR TITLE
Fix issue with duplicate Error messing up the exported Error type

### DIFF
--- a/src/backend/switch/tungstenite.rs
+++ b/src/backend/switch/tungstenite.rs
@@ -1,12 +1,14 @@
 //! tungstenite WebSocket backend.
 
-use crate::prelude::*;
 use crate::error::WebsocketResult;
-use tokio_tungstenite::{connect_async, WebSocketStream, MaybeTlsStream};
-pub use tokio_tungstenite::tungstenite::Error;
-use tokio::net::TcpStream;
+use crate::prelude::*;
 use futures_util::SinkExt;
 use std::sync::{Arc, Mutex};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+/// The underlying error is a tungstenite error, which is very specific
+pub type BackendError = tokio_tungstenite::tungstenite::Error;
 
 use crate::message::Message;
 use futures_util::StreamExt;
@@ -17,17 +19,13 @@ use futures_util::stream::{SplitSink, SplitStream};
 impl From<tokio_tungstenite::tungstenite::Message> for Message {
     fn from(message: tokio_tungstenite::tungstenite::Message) -> Self {
         match message {
-            tokio_tungstenite::tungstenite::Message::Binary(binary) => {
-                Message::Binary(binary)
-            },
-            tokio_tungstenite::tungstenite::Message::Text(text) => {
-                Message::Text(text)
-            },
+            tokio_tungstenite::tungstenite::Message::Binary(binary) => Message::Binary(binary),
+            tokio_tungstenite::tungstenite::Message::Text(text) => Message::Text(text),
             tokio_tungstenite::tungstenite::Message::Close(close) => {
                 let close = close.map(|close| close.reason.to_string());
                 Message::Close(close)
-            },
-            _ => unimplemented!("Some message types aren't implemented yet: {:#?}", message)
+            }
+            _ => unimplemented!("Some message types aren't implemented yet: {:#?}", message),
         }
     }
 }
@@ -41,16 +39,23 @@ pub struct WebSocket {}
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]
 pub struct WebSocketSender {
-    #[derivative(Debug="ignore")]
-    sender: Arc<Mutex<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, tokio_tungstenite::tungstenite::Message>>>
+    #[derivative(Debug = "ignore")]
+    sender: Arc<
+        Mutex<
+            SplitSink<
+                WebSocketStream<MaybeTlsStream<TcpStream>>,
+                tokio_tungstenite::tungstenite::Message,
+            >,
+        >,
+    >,
 }
 
 /// Stream-based WebSocket receiver.
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct WebSocketReceiver {
-    #[derivative(Debug="ignore")]
-    receiver: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>
+    #[derivative(Debug = "ignore")]
+    receiver: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
 }
 
 impl WebSocket {
@@ -74,15 +79,29 @@ impl WebSocketSender {
         match message {
             Message::Text(text) => {
                 let text = text.clone().into();
-                self.sender.lock().expect("Failed to lock sender.").send(text).await.map_err(|error| crate::error::Error::SendError(error))
-            },
+                self.sender
+                    .lock()
+                    .expect("Failed to lock sender.")
+                    .send(text)
+                    .await
+                    .map_err(|error| crate::error::Error::SendError(error))
+            }
             Message::Binary(binary) => {
                 let binary = binary.clone().into();
-                self.sender.lock().expect("Failed to lock sender.").send(binary).await.map_err(|error| crate::error::Error::SendError(error))
-            },
-            Message::Close(_close) => {
-                self.sender.lock().expect("Failed to lock sender.").close().await.map_err(|error| crate::error::Error::SendError(error))
+                self.sender
+                    .lock()
+                    .expect("Failed to lock sender.")
+                    .send(binary)
+                    .await
+                    .map_err(|error| crate::error::Error::SendError(error))
             }
+            Message::Close(_close) => self
+                .sender
+                .lock()
+                .expect("Failed to lock sender.")
+                .close()
+                .await
+                .map_err(|error| crate::error::Error::SendError(error)),
         }
     }
 
@@ -97,12 +116,8 @@ impl WebSocketReceiver {
     pub async fn next(&mut self) -> Option<WebsocketResult<Message>> {
         self.receiver.next().await.map(|result| {
             result
-                .map(|result| {
-                    result.into()
-                })
-                .map_err(|error| {
-                    crate::error::Error::ReceiveError(error)
-                })
+                .map(|result| result.into())
+                .map_err(|error| crate::error::Error::ReceiveError(error))
         })
     }
 }

--- a/src/backend/switch/web_sys.rs
+++ b/src/backend/switch/web_sys.rs
@@ -2,12 +2,12 @@
 
 use crate::error::WebsocketResult;
 
-use web_sys::{MessageEvent, Event, CloseEvent};
-use wasm_bindgen::{JsValue, JsCast};
-use wasm_bindgen::closure::Closure;
-use js_sys::Function;
-use wasm_bindgen_futures::{JsFuture, spawn_local};
 use crate::Message;
+use js_sys::Function;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::{spawn_local, JsFuture};
+use web_sys::{CloseEvent, Event, MessageEvent};
 
 impl From<MessageEvent> for Message {
     fn from(event: MessageEvent) -> Self {
@@ -25,7 +25,6 @@ impl From<MessageEvent> for Message {
 #[derive(Debug)]
 pub struct WebSocket {}
 
-
 /// WebSocket sender. Also responsible for closing the connection.
 #[derive(Debug, Clone)]
 pub struct WebSocketSender {
@@ -37,7 +36,7 @@ pub struct WebSocketSender {
 pub struct WebSocketReceiver {
     receiver: async_channel::Receiver<WebsocketResult<Message>>,
     _on_message_callback: Closure<dyn FnMut(MessageEvent)>,
-    _on_close_callback: Closure<dyn FnMut(CloseEvent)>
+    _on_close_callback: Closure<dyn FnMut(CloseEvent)>,
 }
 
 impl WebSocket {
@@ -50,7 +49,10 @@ impl WebSocket {
             // Connection
             let websocket = web_sys::WebSocket::new(url).expect("Couldn't create WebSocket.");
             {
-                let js_value = websocket.clone().dyn_into::<JsValue>().expect("Couldn't cast WebSocket to JsValue.");
+                let js_value = websocket
+                    .clone()
+                    .dyn_into::<JsValue>()
+                    .expect("Couldn't cast WebSocket to JsValue.");
                 let onopen_callback = Closure::wrap(Box::new(move |_event| {
                     accept.call1(&JsValue::NULL, &js_value).ok();
                 }) as Box<dyn FnMut(Event)>);
@@ -67,33 +69,44 @@ impl WebSocket {
         }) as Box<dyn FnMut(Function, Function)>;
         let connection_promise = js_sys::Promise::new(&mut connection_callback);
 
-        JsFuture::from(connection_promise).await.map(move |websocket| {
-            let websocket: web_sys::WebSocket = websocket.dyn_into().expect("Couldn't cast JsValue to WebSocket.");
+        JsFuture::from(connection_promise)
+            .await
+            .map(move |websocket| {
+                let websocket: web_sys::WebSocket = websocket
+                    .dyn_into()
+                    .expect("Couldn't cast JsValue to WebSocket.");
 
-            // Message streaming.
-            let _on_message_callback = {
-                let sender = sender.clone();
-                let _on_message_callback = Closure::wrap(Box::new(move |e: MessageEvent| {
+                // Message streaming.
+                let _on_message_callback = {
                     let sender = sender.clone();
-                    spawn_local(async move {
-                        sender.send(Ok(e.into())).await.ok();
+                    let _on_message_callback = Closure::wrap(Box::new(move |e: MessageEvent| {
+                        let sender = sender.clone();
+                        spawn_local(async move {
+                            sender.send(Ok(e.into())).await.ok();
+                        })
                     })
-                }) as Box<dyn FnMut(MessageEvent)>);
-                websocket.set_onmessage(Some(_on_message_callback.as_ref().unchecked_ref()));
-                _on_message_callback
-            };
-            // Close event.
-            let _on_close_callback = Closure::wrap(Box::new(move |_e: CloseEvent| {
-                sender.close();
-            }) as Box<dyn FnMut(CloseEvent)>);
-            websocket.set_onclose(Some(_on_close_callback.as_ref().unchecked_ref()));
+                        as Box<dyn FnMut(MessageEvent)>);
+                    websocket.set_onmessage(Some(_on_message_callback.as_ref().unchecked_ref()));
+                    _on_message_callback
+                };
+                // Close event.
+                let _on_close_callback = Closure::wrap(Box::new(move |_e: CloseEvent| {
+                    sender.close();
+                })
+                    as Box<dyn FnMut(CloseEvent)>);
+                websocket.set_onclose(Some(_on_close_callback.as_ref().unchecked_ref()));
 
-            websocket.set_binary_type(web_sys::BinaryType::Arraybuffer);
-            (
-                WebSocketSender { websocket },
-                WebSocketReceiver { receiver, _on_message_callback, _on_close_callback }
-            )
-        }).map_err(|error| crate::error::Error::ConnectionError(error))
+                websocket.set_binary_type(web_sys::BinaryType::Arraybuffer);
+                (
+                    WebSocketSender { websocket },
+                    WebSocketReceiver {
+                        receiver,
+                        _on_message_callback,
+                        _on_close_callback,
+                    },
+                )
+            })
+            .map_err(|error| crate::error::Error::ConnectionError(error))
     }
 }
 
@@ -107,25 +120,28 @@ impl WebSocketSender {
     pub async fn send(&mut self, message: &Message) -> WebsocketResult<()> {
         if self.websocket.ready_state() == web_sys::WebSocket::OPEN {
             match message {
-                Message::Text(text) => {
-                    self.websocket.send_with_str(&text)
-                        .map_err(|error| crate::error::Error::SendError(error))
-                },
-                Message::Binary(binary) => {
-                    self.websocket.send_with_u8_array(&binary)
-                        .map_err(|error| crate::error::Error::SendError(error))
-                },
+                Message::Text(text) => self
+                    .websocket
+                    .send_with_str(&text)
+                    .map_err(|error| crate::error::Error::SendError(error)),
+                Message::Binary(binary) => self
+                    .websocket
+                    .send_with_u8_array(&binary)
+                    .map_err(|error| crate::error::Error::SendError(error)),
                 Message::Close(reason) => {
                     const NORMAL: u16 = 1000;
                     if let Some(reason) = reason {
                         self.websocket.close_with_code_and_reason(NORMAL, &reason)
                     } else {
                         self.websocket.close_with_code(NORMAL)
-                    }.map_err(|error| crate::error::Error::SendError(error))
+                    }
+                    .map_err(|error| crate::error::Error::SendError(error))
                 }
             }
         } else {
-            Err(crate::error::Error::SendError("Sending while the socket is not open is not allowed.".into()))
+            Err(crate::error::Error::SendError(
+                "Sending while the socket is not open is not allowed.".into(),
+            ))
         }
     }
 }
@@ -137,4 +153,5 @@ impl WebSocketReceiver {
     }
 }
 
-pub type Error = JsValue;
+/// The underlying error is a JavaScript value
+pub type BackendError = JsValue;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,7 +1,6 @@
 //! nash-ws error module.
 
-/// Specific error to each backend.
-pub type BackendError = crate::backend::Error;
+use crate::BackendError;
 
 /// All possible errors emitted by the WebSocket.
 #[derive(Debug)]
@@ -11,7 +10,7 @@ pub enum Error {
     /// Error emitted if sending a message fails.
     SendError(BackendError),
     /// Error emitted if receiving a message fails.
-    ReceiveError(BackendError)
+    ReceiveError(BackendError),
 }
 
 /// Result type of nash-ws.


### PR DESCRIPTION
Was also automatically formatted using `rustfmt`. Fixes #13 